### PR TITLE
Clone state data before archiving month rollover

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,10 +562,11 @@
         state.data.debts = debts;
 
         // Archive snapshot incl. payments summary
+        const snapshotData = JSON.parse(JSON.stringify(state.data || {}));
         const archiveEntry = {
           month: prevMonth,
           ts: Date.now(),
-          data: state.data || {},
+          data: snapshotData,
           expenses: prevMonthExpenses,
           carryOver: carryOver,
           payments: {
@@ -576,10 +577,11 @@
         state.archives.push(archiveEntry);
       } else {
         // No auto-apply: archive without altering debts
+        const snapshotData = JSON.parse(JSON.stringify(state.data || {}));
         const archiveEntry = {
           month: prevMonth,
           ts: Date.now(),
-          data: state.data || {},
+          data: snapshotData,
           expenses: prevMonthExpenses,
           carryOver: carryOver
         };


### PR DESCRIPTION
## Summary
- clone the live month state before writing archive entries
- store the cloned data snapshot when archiving both auto-apply and manual rollovers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5bd54c5f08327b476dce537df4464