### PR TITLE
Ensure rollover archives snapshot before new month updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,6 +546,8 @@
       const ds = (state.data && state.data.debtSettings) || {};
       const autoApply = !!ds.autoApply;
 
+      const snapshotData = JSON.parse(JSON.stringify(state.data || {}));
+
       if (autoApply && debts.length){
         // 1) Apply per-debt minimums (reduce balances)
         debts.forEach(d => {
@@ -558,14 +560,11 @@
           }
         });
 
-        // Write updated debts back
-        state.data.debts = debts;
-
         // Archive snapshot incl. payments summary
         const archiveEntry = {
           month: prevMonth,
           ts: Date.now(),
-          data: state.data || {},
+          data: snapshotData,
           expenses: prevMonthExpenses,
           carryOver: carryOver,
           payments: {
@@ -574,12 +573,15 @@
           }
         };
         state.archives.push(archiveEntry);
+
+        // Write updated debts back for the new month after archiving snapshot
+        state.data.debts = debts;
       } else {
         // No auto-apply: archive without altering debts
         const archiveEntry = {
           month: prevMonth,
           ts: Date.now(),
-          data: state.data || {},
+          data: snapshotData,
           expenses: prevMonthExpenses,
           carryOver: carryOver
         };


### PR DESCRIPTION
## Summary
- clone the current month state once before making rollover adjustments
- archive that cloned snapshot for both auto-apply and manual rollover flows so the archive holds the untouched month-end data
- update auto-applied debt balances only after storing the archive entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5bd54c5f08327b476dce537df4464