### PR TITLE
Fix syntax error in debt reader

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,7 +854,7 @@
     return [...debtsTbl.querySelectorAll("tr")].map(r=>{
       const [name,balance,min,due,contractEnd,notes]=[...r.querySelectorAll("input")].map(x=>x.value);
       const id=r.dataset.id||"";
-      return {id, name, balance:+balance||0, min:+min||0, due, contractEnd, notes}; main
+      return {id, name, balance:+balance||0, min:+min||0, due, contractEnd, notes};
     });
   }
   function updateDebtTotals(){


### PR DESCRIPTION
## Summary
- remove stray text after debt row parsing to restore valid JavaScript

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5c321a3b083279c2a28a9013799fc