### PR TITLE
Convert overview cards into modal dialogs

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,10 +45,18 @@
   .btn.primary{background:var(--accent);color:#050714;border-color:var(--accent);box-shadow:0 16px 32px -22px rgba(124,155,255,.9)}
   .btn.ghost{background:rgba(12,15,30,.6);border-color:rgba(124,155,255,.2);padding:7px 12px;line-height:1}
   .btn.icon{width:32px;aspect-ratio:1;border-radius:10px}
-  main.layout{max-width:1200px;margin:0 auto;padding:20px 18px 90px;display:grid;gap:1rem;align-items:start}
+  main.layout{max-width:1200px;margin:0 auto;padding:20px 18px 90px;display:grid;gap:1.5rem;align-items:start;grid-template-columns:1fr;justify-items:stretch}
   .grid{display:grid;grid-template-columns:minmax(0,1fr);gap:1rem;align-content:start;justify-items:stretch}
   .col{min-width:0}
   .card{background:var(--elev-1);border:1px solid color-mix(in oklch,var(--accent) 12%,transparent);border-radius:18px;box-shadow:var(--shadow-lg);padding:0;position:relative;overflow:hidden}
+  .sectionGrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:1.2rem;align-items:stretch}
+  .sectionButton{display:flex;flex-direction:column;align-items:flex-start;gap:.75rem;text-align:left;padding:24px 22px;border-radius:18px;border:1px solid color-mix(in oklch,var(--accent) 18%,transparent);background:linear-gradient(135deg,rgba(124,155,255,.18),rgba(124,155,255,.04));box-shadow:var(--shadow-lg);color:var(--surface-ink);cursor:pointer;transition:transform .18s ease,box-shadow .22s ease,border-color .22s ease;min-height:150px}
+  .sectionButton:hover{transform:translateY(-1px);box-shadow:0 26px 54px -40px rgba(124,155,255,.55);border-color:color-mix(in oklch,var(--accent) 55%,transparent)}
+  .sectionButton:active{transform:translateY(0)}
+  .sectionButton:focus-visible{outline:2px solid color-mix(in oklch,var(--accent) 85%,white 10%);outline-offset:3px}
+  .sectionButton__label{font-size:1.05rem;font-weight:600;letter-spacing:.01em}
+  .sectionButton__hint{font-size:.83rem;color:var(--muted);max-width:32ch}
+  .sectionButton__pill{margin-top:auto}
   .card:not([data-sticky]){scroll-margin-top:calc(var(--header-h) + 14px)}
   details[data-accordion]{display:block}
   details[data-accordion] > summary{display:flex;align-items:center;justify-content:space-between;gap:.75rem;padding:14px 18px;cursor:pointer;list-style:none;background:linear-gradient(90deg,rgba(124,155,255,.14),rgba(124,155,255,0));font-size:.95rem}
@@ -109,27 +117,32 @@
   .dialog-body{padding:18px;display:flex;flex-direction:column;gap:.6rem}
   .dialog-actions{padding:16px 18px;border-top:1px solid rgba(255,255,255,.08);display:flex;justify-content:flex-end;gap:.6rem}
   .pill{display:inline-flex;align-items:center;gap:.5rem;padding:6px 12px;border-radius:999px;border:1px solid rgba(124,155,255,.22);font-size:.75rem;background:rgba(124,155,255,.14);color:var(--accent);font-weight:600}
+  dialog[data-section-dialog]{width:min(900px,96vw);max-height:92vh;display:flex;flex-direction:column}
+  dialog[data-section-dialog] .dialog-body{flex:1;overflow:auto;padding:22px 24px;gap:1rem}
+  .sectionDialog__summary{display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;gap:.6rem;font-size:.85rem;color:var(--muted)}
+  .sectionDialog__summary .pill{margin-right:auto}
+  .sectionDialog__hint{font-size:.82rem;color:var(--muted)}
+  .sectionDialog__scroll{display:flex;flex-direction:column;gap:1rem}
+  dialog[data-section-dialog] .card-body{padding:0;border:none}
   :focus-visible{outline:2px solid color-mix(in oklch,var(--accent) 85%,white 10%);outline-offset:2px}
   .card[data-sticky]{top:calc(var(--header-h) + 16px);align-self:start;z-index:5}
   @media (min-width:980px){
-    body{overflow:hidden}
-    main.layout{grid-template-columns:minmax(0,1.15fr) minmax(0,.85fr);height:calc(100vh - var(--header-h));padding:20px 22px 40px}
-    .col--primary,.col--secondary{min-height:0;overflow:auto;padding-right:.6rem;padding-bottom:1.5rem;scrollbar-gutter:stable both-edges}
-    .card{flex:0 0 auto}
+    body{overflow:auto}
+    main.layout{grid-template-columns:1fr;padding:20px 22px 60px}
+    .sectionGrid{grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1.4rem}
   }
   @media (max-width:979px){
     header.appBar{grid-template-columns:minmax(0,1fr);grid-template-rows:auto auto auto;gap:.75rem;padding:16px 16px 14px}
     header.appBar .monthNav{order:3}
     header.appBar .btn.primary{width:100%;order:2}
     main.layout{grid-template-columns:1fr;padding:16px 14px 80px}
-    .col--primary,.col--secondary{overflow:visible;padding-right:0}
+    .sectionGrid{grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1.1rem}
     .fieldRow{grid-template-columns:1fr}
-    .card{border-radius:16px}
-    details[data-accordion] > summary{padding:14px 16px;font-size:.92rem}
-    .card-body{padding:16px}
     .breakdown{grid-template-columns:repeat(auto-fill,minmax(180px,1fr))}
   }
   @media (max-width:640px){
+    .sectionGrid{grid-template-columns:1fr;gap:1rem}
+    .sectionButton{width:100%;min-height:clamp(160px,32dvh,220px);padding:22px 20px}
     .tableToolbar input{width:100%;max-width:100%}
     th,td{padding:9px 10px}
     table{min-width:540px}
@@ -161,284 +174,341 @@
   <button class="btn primary" id="expQuick" type="button">Lisa kulu</button>
 </header>
 
-<main class="layout grid-2">
-  <section class="col col--primary grid">
-    <article class="card">
-      <details open data-accordion>
-        <summary>
-          <span class="chev" aria-hidden="true">▶</span>
-          <h2>Sissetulek ja püsikulud (kuu)</h2>
-          <span class="pill" id="pillBudget">—</span>
-        </summary>
-        <div class="card-body">
-          <div class="fieldRow">
-            <label for="income">Kuu netosissetulek</label>
-            <div class="field currency">
-              <input id="income" class="currency" type="text" inputmode="decimal" autocomplete="off" aria-errormessage="incomeErr">
-              <p class="err" id="incomeErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <h3 class="helper">Püsikohustused</h3>
-          <div class="fieldRow">
-            <label for="loans">Laenud</label>
-            <div class="field">
-              <div class="payWrap">
-                <div class="field currency" style="flex:1">
-                  <input id="loans" class="currency" type="text" inputmode="decimal" aria-errormessage="loansErr">
-                  <p class="err" id="loansErr" hidden role="alert"></p>
-                </div>
-                <button class="btn payToggle" type="button" data-key="loans" aria-pressed="false">Maksmata</button>
-              </div>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="mom">Toetus emale</label>
-            <div class="field">
-              <div class="payWrap">
-                <div class="field currency" style="flex:1">
-                  <input id="mom" class="currency" type="text" inputmode="decimal" aria-errormessage="momErr">
-                  <p class="err" id="momErr" hidden role="alert"></p>
-                </div>
-                <div class="field" style="min-width:160px">
-                  <input id="momEnd" type="date" aria-describedby="momEndHelp">
-                  <p class="helper" id="momEndHelp">Lõppkuupäev (k.a), kui kohustus lõpeb.</p>
-                </div>
-                <button class="btn payToggle" type="button" data-key="mom" aria-pressed="false">Maksmata</button>
-              </div>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="aptSupport">Korteri tugi õele</label>
-            <div class="field">
-              <div class="payWrap">
-                <div class="field currency" style="flex:1">
-                  <input id="aptSupport" class="currency" type="text" inputmode="decimal" aria-errormessage="aptSupportErr">
-                  <p class="err" id="aptSupportErr" hidden role="alert"></p>
-                </div>
-                <div class="field" style="min-width:160px">
-                  <input id="aptSupportEnd" type="date" aria-describedby="aptEndHelp">
-                  <p class="helper" id="aptEndHelp">Lõppkuupäev (k.a), kui tugi lõpeb.</p>
-                </div>
-                <button class="btn payToggle" type="button" data-key="aptSupport" aria-pressed="false">Maksmata</button>
-              </div>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="phone">Telefon/Internet</label>
-            <div class="field currency">
-              <input id="phone" class="currency" type="text" inputmode="decimal" aria-errormessage="phoneErr">
-              <p class="err" id="phoneErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="transport">Transport</label>
-            <div class="field currency">
-              <input id="transport" class="currency" type="text" inputmode="decimal" aria-errormessage="transportErr">
-              <p class="err" id="transportErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="groceries">Toit</label>
-            <div class="field currency">
-              <input id="groceries" class="currency" type="text" inputmode="decimal" aria-errormessage="groceriesErr">
-              <p class="err" id="groceriesErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="otherEss">Muud esmavajadused</label>
-            <div class="field currency">
-              <input id="otherEss" class="currency" type="text" inputmode="decimal" aria-errormessage="otherEssErr">
-              <p class="err" id="otherEssErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <h3 class="helper">Vaba valik</h3>
-          <div class="fieldRow">
-            <label for="fun">Meelelahutus</label>
-            <div class="field currency">
-              <input id="fun" class="currency" type="text" inputmode="decimal" aria-errormessage="funErr">
-              <p class="err" id="funErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="personal">Riided/Isiklik</label>
-            <div class="field currency">
-              <input id="personal" class="currency" type="text" inputmode="decimal" aria-errormessage="personalErr">
-              <p class="err" id="personalErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="zazaCap">Kanepi kulu ülempiir</label>
-            <div class="field currency">
-              <input id="zazaCap" class="currency" type="text" inputmode="decimal" aria-errormessage="zazaCapErr">
-              <p class="err" id="zazaCapErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <h3 class="helper">Ohutus ja eesmärgid</h3>
-          <div class="fieldRow">
-            <label for="efTarget">Hädaabifondi siht</label>
-            <div class="field currency">
-              <input id="efTarget" class="currency" type="text" inputmode="decimal" aria-errormessage="efTargetErr">
-              <p class="err" id="efTargetErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="efNow">Hädaabifondi jääk</label>
-            <div class="field currency">
-              <input id="efNow" class="currency" type="text" inputmode="decimal" aria-errormessage="efNowErr">
-              <p class="err" id="efNowErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="paydaysInput">Palgapäev (nt 5 või 5,20)</label>
-            <div class="field">
-              <input id="paydaysInput" placeholder="Lisa päevad komaga eraldatult" aria-describedby="paydaysHelp">
-              <p class="helper" id="paydaysHelp">Arvuta järgnevate maksepäevade vahe automaatselt.</p>
-              <div class="helper" id="nextPayInfo"></div>
-            </div>
-          </div>
-          <div class="kpi">
-            <div class="box"><div class="label">Väljavool kokku</div><div class="val" id="kpiOut">—</div></div>
-            <div class="box"><div class="label">Ülejääk / Puudujääk</div><div class="val" id="kpiLeft">—</div></div>
-            <div class="box"><div class="label">Jaotus</div><div class="val" id="kpiAlloc">—</div></div>
-          </div>
-        </div>
-      </details>
-    </article>
-    <article class="card">
-      <details data-accordion>
-        <summary>
-          <span class="chev" aria-hidden="true">▶</span>
-          <h2>Kanepi tegelikkuse kontroll</h2>
-          <span class="pill" id="pillZaza">Zaza alles: —</span>
-        </summary>
-        <div class="card-body">
-          <div class="fieldRow">
-            <label for="pricePerGram">Hind €/g</label>
-            <div class="field currency">
-              <input id="pricePerGram" class="currency" type="text" inputmode="decimal" aria-errormessage="priceErr">
-              <p class="err" id="priceErr" hidden role="alert"></p>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="gramsPerWeek">Gramme nädalas</label>
-            <div class="field">
-              <input id="gramsPerWeek" type="number" min="0" step="0.1">
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="zazaAuto">Kuu kulu (auto)</label>
-            <div class="field currency">
-              <input id="zazaAuto" class="currency" type="text" inputmode="decimal" disabled>
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label for="zazaCutPct">Vähenda (%)</label>
-            <div class="field">
-              <input id="zazaCutPct" type="number" min="0" max="100" step="1">
-            </div>
-          </div>
-          <div class="fieldRow">
-            <label aria-hidden="true"></label>
-            <div class="field">
-              <button class="btn" id="applyCap" type="button">Sea ülempiir ja liiguta sääst EF-i</button>
-              <p class="helper" id="capMsg"></p>
-              <div class="progress" aria-hidden="true"><div id="zazaProg"></div></div>
-            </div>
-          </div>
-        </div>
-      </details>
-    </article>
-
-    <article class="card" id="expSection">
-      <details open data-accordion>
-        <summary>
-          <span class="chev" aria-hidden="true">▶</span>
-          <h2>Selle kuu kulud</h2>
-          <span class="pill" id="pillSpent">Sel kuul: —</span>
-        </summary>
-        <div class="card-body">
-          <div class="tableToolbar">
-            <label for="expFilter">Filtreeri</label>
-            <input id="expFilter" type="search" placeholder="Otsi kategooria või märkuse järgi">
-          </div>
-          <div class="tableWrap">
-            <table id="expTbl" class="exp-table" aria-live="polite">
-              <thead>
-                <tr>
-                  <th><button type="button" data-sort="date">Kuupäev <span class="sortIcon" aria-hidden="true">⇅</span></button></th>
-                  <th>Kategooria</th>
-                  <th>Märkus</th>
-                  <th class="right"><button type="button" data-sort="amount">€ <span class="sortIcon" aria-hidden="true">⇅</span></button></th>
-                  <th aria-label="Tegevused"></th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-              <tfoot>
-                <tr><td colspan="3"><strong>Kokku (kuu):</strong></td><td class="right" id="expSum">0.00</td><td></td></tr>
-              </tfoot>
-            </table>
-          </div>
-        </div>
-      </details>
-    </article>
-  </section>
-
-  <aside class="col col--secondary grid">
-    <article class="card" data-sticky>
-      <details open data-accordion>
-        <summary>
-          <span class="chev" aria-hidden="true">▶</span>
-          <h2>Jooksev kokkuvõte</h2>
-        </summary>
-        <div class="card-body">
-          <div class="summaryList" id="liveSummary" aria-live="polite"></div>
-          <p class="summaryNote">Tabel peegeldab valitud kuu seisu.</p>
-          <section>
-            <h3 style="font-size:.85rem;margin-top:.6rem">Kategooriate jälgimine</h3>
-            <div class="breakdown" id="expBreakdown"></div>
-          </section>
-        </div>
-      </details>
-    </article>
-
-    <article class="card">
-      <details data-accordion>
-        <summary>
-          <span class="chev" aria-hidden="true">▶</span>
-          <h2>Arhiiv (varasemad kuud)</h2>
-        </summary>
-        <div class="card-body">
-          <div id="archivesList" class="summaryList"></div>
-        </div>
-      </details>
-    </article>
-
-    <article class="card">
-      <details data-accordion>
-        <summary>
-          <span class="chev" aria-hidden="true">▶</span>
-          <h2>Psühholoogianipid</h2>
-        </summary>
-        <div class="card-body">
-          <h3 style="font-size:.9rem">Tegevuskavad</h3>
-          <textarea id="implIntents">Kui kell on pärast 22:30 ja tekib isu, teen teed ja teen 8-min venituse; kui ikka tahan, jään oma piirangu juurde.</textarea>
-          <h3 style="font-size:.9rem">Tahtmise laine (3 minutit)</h3>
-          <div class="payWrap">
-            <button class="btn" id="startUrge" type="button">Käivita 3:00</button>
-            <div id="urgeClock" class="pill">03:00</div>
-          </div>
-          <h3 style="font-size:.9rem">Nädalane kontroll (10 min)</h3>
-          <ul class="summaryList" style="gap:.3rem">
-            <li>Logi tegelikud kulud eelarvesse.</li>
-            <li>Kontrolli kanepi “ümbriku”/alamkontot.</li>
-            <li>Kui läheb üle, kärbi sel nädalal (mitte järgmisel kuul).</li>
-            <li>Tähista üks võit (nt “€40 → Hädaabifond”).</li>
-          </ul>
-        </div>
-      </details>
-    </article>
-  </aside>
+<main class="layout">
+  <div class="sectionGrid">
+    <button class="sectionButton" type="button" data-dialog-target="dlg-budget">
+      <span class="sectionButton__label">Sissetulek ja püsikulud (kuu)</span>
+      <span class="pill sectionButton__pill" data-pill="budget">—</span>
+      <span class="sectionButton__hint">Vaata ja uuenda igakuised kohustused.</span>
+    </button>
+    <button class="sectionButton" type="button" data-dialog-target="dlg-summary">
+      <span class="sectionButton__label">Jooksev kokkuvõte</span>
+      <span class="sectionButton__hint">Kiire ülevaade valitud kuu seisu kohta.</span>
+    </button>
+    <button class="sectionButton" type="button" data-dialog-target="dlg-zaza">
+      <span class="sectionButton__label">Kanepi tegelikkuse kontroll</span>
+      <span class="pill sectionButton__pill" data-pill="zaza">Zaza alles: —</span>
+      <span class="sectionButton__hint">Planeeri kulud ja sea vajadusel ülempiir.</span>
+    </button>
+    <button class="sectionButton" type="button" data-dialog-target="dlg-expenses">
+      <span class="sectionButton__label">Selle kuu kulud</span>
+      <span class="pill sectionButton__pill" data-pill="spent">Sel kuul: —</span>
+      <span class="sectionButton__hint">Filtreeri ja halda kuu jooksul tehtud kulusid.</span>
+    </button>
+    <button class="sectionButton" type="button" data-dialog-target="dlg-archive">
+      <span class="sectionButton__label">Arhiiv (varasemad kuud)</span>
+      <span class="sectionButton__hint">Sirvi automaatselt salvestatud kuu kokkuvõtteid.</span>
+    </button>
+    <button class="sectionButton" type="button" data-dialog-target="dlg-tips">
+      <span class="sectionButton__label">Psühholoogianipid</span>
+      <span class="sectionButton__hint">Hoia eesmärke värskena ja kasuta toetavaid rutiine.</span>
+    </button>
+  </div>
 </main>
+
+<dialog id="dlg-budget" data-section-dialog aria-labelledby="dlg-budget-title">
+  <div class="dialog-head">
+    <h3 id="dlg-budget-title" style="margin:0">Sissetulek ja püsikulud (kuu)</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body">
+    <div class="sectionDialog__summary">
+      <span class="pill" data-pill="budget">—</span>
+      <p class="sectionDialog__hint">Jälgi sissetulekut ja püsikohustusi ning vaata, kui palju jääb alles.</p>
+    </div>
+    <div class="sectionDialog__scroll">
+      <div class="card-body">
+        <div class="fieldRow">
+          <label for="income">Kuu netosissetulek</label>
+          <div class="field currency">
+            <input id="income" class="currency" type="text" inputmode="decimal" autocomplete="off" aria-errormessage="incomeErr">
+            <p class="err" id="incomeErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <h3 class="helper">Püsikohustused</h3>
+        <div class="fieldRow">
+          <label for="loans">Laenud</label>
+          <div class="field">
+            <div class="payWrap">
+              <div class="field currency" style="flex:1">
+                <input id="loans" class="currency" type="text" inputmode="decimal" aria-errormessage="loansErr">
+                <p class="err" id="loansErr" hidden role="alert"></p>
+              </div>
+              <button class="btn payToggle" type="button" data-key="loans" aria-pressed="false">Maksmata</button>
+            </div>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="mom">Toetus emale</label>
+          <div class="field">
+            <div class="payWrap">
+              <div class="field currency" style="flex:1">
+                <input id="mom" class="currency" type="text" inputmode="decimal" aria-errormessage="momErr">
+                <p class="err" id="momErr" hidden role="alert"></p>
+              </div>
+              <div class="field" style="min-width:160px">
+                <input id="momEnd" type="date" aria-describedby="momEndHelp">
+                <p class="helper" id="momEndHelp">Lõppkuupäev (k.a), kui kohustus lõpeb.</p>
+              </div>
+              <button class="btn payToggle" type="button" data-key="mom" aria-pressed="false">Maksmata</button>
+            </div>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="aptSupport">Korteri tugi õele</label>
+          <div class="field">
+            <div class="payWrap">
+              <div class="field currency" style="flex:1">
+                <input id="aptSupport" class="currency" type="text" inputmode="decimal" aria-errormessage="aptSupportErr">
+                <p class="err" id="aptSupportErr" hidden role="alert"></p>
+              </div>
+              <div class="field" style="min-width:160px">
+                <input id="aptSupportEnd" type="date" aria-describedby="aptEndHelp">
+                <p class="helper" id="aptEndHelp">Lõppkuupäev (k.a), kui tugi lõpeb.</p>
+              </div>
+              <button class="btn payToggle" type="button" data-key="aptSupport" aria-pressed="false">Maksmata</button>
+            </div>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="phone">Telefon/Internet</label>
+          <div class="field currency">
+            <input id="phone" class="currency" type="text" inputmode="decimal" aria-errormessage="phoneErr">
+            <p class="err" id="phoneErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="transport">Transport</label>
+          <div class="field currency">
+            <input id="transport" class="currency" type="text" inputmode="decimal" aria-errormessage="transportErr">
+            <p class="err" id="transportErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="groceries">Toit</label>
+          <div class="field currency">
+            <input id="groceries" class="currency" type="text" inputmode="decimal" aria-errormessage="groceriesErr">
+            <p class="err" id="groceriesErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="otherEss">Muud esmavajadused</label>
+          <div class="field currency">
+            <input id="otherEss" class="currency" type="text" inputmode="decimal" aria-errormessage="otherEssErr">
+            <p class="err" id="otherEssErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <h3 class="helper">Vaba valik</h3>
+        <div class="fieldRow">
+          <label for="fun">Meelelahutus</label>
+          <div class="field currency">
+            <input id="fun" class="currency" type="text" inputmode="decimal" aria-errormessage="funErr">
+            <p class="err" id="funErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="personal">Riided/Isiklik</label>
+          <div class="field currency">
+            <input id="personal" class="currency" type="text" inputmode="decimal" aria-errormessage="personalErr">
+            <p class="err" id="personalErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="zazaCap">Kanepi kulu ülempiir</label>
+          <div class="field currency">
+            <input id="zazaCap" class="currency" type="text" inputmode="decimal" aria-errormessage="zazaCapErr">
+            <p class="err" id="zazaCapErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <h3 class="helper">Ohutus ja eesmärgid</h3>
+        <div class="fieldRow">
+          <label for="efTarget">Hädaabifondi siht</label>
+          <div class="field currency">
+            <input id="efTarget" class="currency" type="text" inputmode="decimal" aria-errormessage="efTargetErr">
+            <p class="err" id="efTargetErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="efNow">Hädaabifondi jääk</label>
+          <div class="field currency">
+            <input id="efNow" class="currency" type="text" inputmode="decimal" aria-errormessage="efNowErr">
+            <p class="err" id="efNowErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="paydaysInput">Palgapäev (nt 5 või 5,20)</label>
+          <div class="field">
+            <input id="paydaysInput" placeholder="Lisa päevad komaga eraldatult" aria-describedby="paydaysHelp">
+            <p class="helper" id="paydaysHelp">Arvuta järgnevate maksepäevade vahe automaatselt.</p>
+            <div class="helper" id="nextPayInfo"></div>
+          </div>
+        </div>
+        <div class="kpi">
+          <div class="box"><div class="label">Väljavool kokku</div><div class="val" id="kpiOut">—</div></div>
+          <div class="box"><div class="label">Ülejääk / Puudujääk</div><div class="val" id="kpiLeft">—</div></div>
+          <div class="box"><div class="label">Jaotus</div><div class="val" id="kpiAlloc">—</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="dlg-summary" data-section-dialog aria-labelledby="dlg-summary-title">
+  <div class="dialog-head">
+    <h3 id="dlg-summary-title" style="margin:0">Jooksev kokkuvõte</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body">
+    <div class="sectionDialog__summary">
+      <p class="sectionDialog__hint">Tabel ja jaotus peegeldavad valitud kuu seisu.</p>
+    </div>
+    <div class="sectionDialog__scroll">
+      <div class="card-body">
+        <div class="summaryList" id="liveSummary" aria-live="polite"></div>
+        <p class="summaryNote">Tabel peegeldab valitud kuu seisu.</p>
+        <section>
+          <h3 style="font-size:.85rem;margin-top:.6rem">Kategooriate jälgimine</h3>
+          <div class="breakdown" id="expBreakdown"></div>
+        </section>
+      </div>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="dlg-zaza" data-section-dialog aria-labelledby="dlg-zaza-title">
+  <div class="dialog-head">
+    <h3 id="dlg-zaza-title" style="margin:0">Kanepi tegelikkuse kontroll</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body">
+    <div class="sectionDialog__summary">
+      <span class="pill" data-pill="zaza">Zaza alles: —</span>
+      <p class="sectionDialog__hint">Sisesta harjumused ja vajadusel kärbi kulusid.</p>
+    </div>
+    <div class="sectionDialog__scroll">
+      <div class="card-body">
+        <div class="fieldRow">
+          <label for="pricePerGram">Hind €/g</label>
+          <div class="field currency">
+            <input id="pricePerGram" class="currency" type="text" inputmode="decimal" aria-errormessage="priceErr">
+            <p class="err" id="priceErr" hidden role="alert"></p>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="gramsPerWeek">Gramme nädalas</label>
+          <div class="field">
+            <input id="gramsPerWeek" type="number" min="0" step="0.1">
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="zazaAuto">Kuu kulu (auto)</label>
+          <div class="field currency">
+            <input id="zazaAuto" class="currency" type="text" inputmode="decimal" disabled>
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label for="zazaCutPct">Vähenda (%)</label>
+          <div class="field">
+            <input id="zazaCutPct" type="number" min="0" max="100" step="1">
+          </div>
+        </div>
+        <div class="fieldRow">
+          <label aria-hidden="true"></label>
+          <div class="field">
+            <button class="btn" id="applyCap" type="button">Sea ülempiir ja liiguta sääst EF-i</button>
+            <p class="helper" id="capMsg"></p>
+            <div class="progress" aria-hidden="true"><div id="zazaProg"></div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="dlg-expenses" data-section-dialog aria-labelledby="dlg-expenses-title">
+  <div class="dialog-head">
+    <h3 id="dlg-expenses-title" style="margin:0">Selle kuu kulud</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body">
+    <div class="sectionDialog__summary">
+      <span class="pill" data-pill="spent">Sel kuul: —</span>
+      <p class="sectionDialog__hint">Filtreeri kirjeid ja vaata kogusummat.</p>
+    </div>
+    <div class="sectionDialog__scroll">
+      <div class="card-body" id="expSection">
+        <div class="tableToolbar">
+          <label for="expFilter">Filtreeri</label>
+          <input id="expFilter" type="search" placeholder="Otsi kategooria või märkuse järgi">
+        </div>
+        <div class="tableWrap">
+          <table id="expTbl" class="exp-table" aria-live="polite">
+            <thead>
+              <tr>
+                <th><button type="button" data-sort="date">Kuupäev <span class="sortIcon" aria-hidden="true">⇅</span></button></th>
+                <th>Kategooria</th>
+                <th>Märkus</th>
+                <th class="right"><button type="button" data-sort="amount">€ <span class="sortIcon" aria-hidden="true">⇅</span></button></th>
+                <th aria-label="Tegevused"></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+            <tfoot>
+              <tr><td colspan="3"><strong>Kokku (kuu):</strong></td><td class="right" id="expSum">0.00</td><td></td></tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="dlg-archive" data-section-dialog aria-labelledby="dlg-archive-title">
+  <div class="dialog-head">
+    <h3 id="dlg-archive-title" style="margin:0">Arhiiv (varasemad kuud)</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body">
+    <div class="sectionDialog__summary">
+      <p class="sectionDialog__hint">Sirvi automaatselt salvestatud kuu kokkuvõtteid.</p>
+    </div>
+    <div class="sectionDialog__scroll">
+      <div class="card-body">
+        <div id="archivesList" class="summaryList"></div>
+      </div>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="dlg-tips" data-section-dialog aria-labelledby="dlg-tips-title">
+  <div class="dialog-head">
+    <h3 id="dlg-tips-title" style="margin:0">Psühholoogianipid</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body">
+    <div class="sectionDialog__summary">
+      <p class="sectionDialog__hint">Toetavad tegevused aitavad eesmärkidel püsida.</p>
+    </div>
+    <div class="sectionDialog__scroll">
+      <div class="card-body">
+        <h3 style="font-size:.9rem">Tegevuskavad</h3>
+        <textarea id="implIntents">Kui kell on pärast 22:30 ja tekib isu, teen teed ja teen 8-min venituse; kui ikka tahan, jään oma piirangu juurde.</textarea>
+        <h3 style="font-size:.9rem">Tahtmise laine (3 minutit)</h3>
+        <div class="payWrap">
+          <button class="btn" id="startUrge" type="button">Käivita 3:00</button>
+          <div id="urgeClock" class="pill">03:00</div>
+        </div>
+        <h3 style="font-size:.9rem">Nädalane kontroll (10 min)</h3>
+        <ul class="summaryList" style="gap:.3rem">
+          <li>Logi tegelikud kulud eelarvesse.</li>
+          <li>Kontrolli kanepi “ümbriku”/alamkontot.</li>
+          <li>Kui läheb üle, kärbi sel nädalal (mitte järgmisel kuul).</li>
+          <li>Tähista üks võit (nt “€40 → Hädaabifond”).</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</dialog>
 <dialog id="expDialog" aria-label="Lisa kulu">
   <div class="dialog-head">
     <h3 style="margin:0">Lisa kulu</h3>
@@ -618,9 +688,16 @@
   };
 
   const summary = $('#liveSummary');
-  const pillBudget = $('#pillBudget');
-  const pillZaza = $('#pillZaza');
-  const pillSpent = $('#pillSpent');
+  const pillTargets = {
+    budget: $$('[data-pill="budget"]'),
+    zaza: $$('[data-pill="zaza"]'),
+    spent: $$('[data-pill="spent"]')
+  };
+  const setPillText = (key, text) => {
+    (pillTargets[key] || []).forEach(el => {
+      el.textContent = text;
+    });
+  };
   const zazaProg = $('#zazaProg');
   const archivesList = $('#archivesList');
   const expBreakdown = $('#expBreakdown');
@@ -903,10 +980,9 @@
   }
 
   function refreshZazaLeft(expenses=currentMonthExpenses, capValue=+inputValue(inputs.zazaCap)||0){
-    if(!pillZaza) return;
     const spent = (expenses||[]).filter(e=>e.cat==='Zaza').reduce((sum,e)=>sum+(+e.amt||0),0);
     const left = Math.max(0, capValue - spent);
-    pillZaza.textContent = `Zaza alles: € ${fmt2(left)}`;
+    setPillText('zaza', `Zaza alles: € ${fmt2(left)}`);
     const usedPct = capValue>0 ? Math.min(100,(spent/capValue)*100) : (spent>0?100:0);
     if(zazaProg){
       zazaProg.style.width = `${usedPct}%`;
@@ -929,7 +1005,7 @@
     const realClass = realLeft>0?'good':(realLeft<0?'bad':'');
     updateKpis(totalOut, realLeft, `Kohustused € ${fmt(obligations)} | Limiidid € ${fmt(limitTotal)} | Plaanijääk € ${fmt(plannedLeft)}`, realClass);
     updateSummaryContent({income, obligations, paidSupports, spent, limitTotal, plannedLeft, realLeft, obligationsLeft});
-    if(pillBudget) pillBudget.textContent = `Reaaljääk: € ${fmt(realLeft)}`;
+    setPillText('budget', `Reaaljääk: € ${fmt(realLeft)}`);
     renderExpenseBreakdown(currentMonthExpenses, inputs, {asOf:new Date()});
     refreshZazaLeft(currentMonthExpenses, +inputValue(inputs.zazaCap)||0);
   }
@@ -989,7 +1065,7 @@
     const alloc = `Kohustused € ${fmt(obligations)} | Limiidid € ${fmt(limitTotal)} | Plaanijääk € ${fmt(plannedLeft)}`;
     updateKpis(obligations+limitTotal, realLeft, alloc, realLeft>0?'good':(realLeft<0?'bad':''));
     updateSummaryContent({income, obligations, paidSupports, spent, limitTotal, plannedLeft, realLeft, obligationsLeft, note:'Arhiivikuul salvestatud seis.'});
-    if(pillBudget) pillBudget.textContent = `Arhiivikuu jääk: € ${fmt(realLeft)}`;
+    setPillText('budget', `Arhiivikuu jääk: € ${fmt(realLeft)}`);
     const cap = +inputValue(budgetInputs.zazaCap)||0;
     refreshZazaLeft(expenses, cap);
     renderExpenseBreakdown(expenses, budgetInputs, {asOf:asOf});
@@ -1051,7 +1127,7 @@
     const total = sorted.reduce((sum,e)=>sum+(+e.amt||0),0);
     if(expSum) expSum.textContent = fmt2(total);
     const monthLabel = formatMonthLabel(viewMonth);
-    if(pillSpent) pillSpent.textContent = `${isCurrent?'Sel kuul':'Valitud kuu'}: € ${fmt2(total)}`;
+    setPillText('spent', `${isCurrent?'Sel kuul':'Valitud kuu'}: € ${fmt2(total)}`);
     updateSortIndicators();
     if(isCurrent){
       recomputeBudget();
@@ -1252,6 +1328,34 @@
   const expDate=expDialog?expDialog.querySelector('#expDate'):document.querySelector('#expDate');
   const expNote=expDialog?expDialog.querySelector('#expNote'):document.querySelector('#expNote');
   const addExp=expDialog?expDialog.querySelector('#addExp'):document.querySelector('#addExp');
+
+  const sectionButtons = $$('[data-dialog-target]');
+  let activeSectionTrigger = null;
+  sectionButtons.forEach(btn => {
+    const targetId = btn.getAttribute('data-dialog-target');
+    if(!targetId) return;
+    const dialog = document.getElementById(targetId);
+    if(!(dialog && typeof dialog.showModal === 'function')) return;
+    dialog.querySelectorAll('[data-dialog-close]').forEach(closeBtn => {
+      closeBtn.addEventListener('click', () => dialog.close());
+    });
+    dialog.addEventListener('cancel', event => {
+      event.preventDefault();
+      dialog.close();
+    });
+    dialog.addEventListener('close', () => {
+      if(activeSectionTrigger){
+        activeSectionTrigger.focus();
+        activeSectionTrigger = null;
+      }
+    });
+    btn.addEventListener('click', () => {
+      activeSectionTrigger = btn;
+      if(!dialog.open){
+        dialog.showModal();
+      }
+    });
+  });
 
   function todayISO(){ const d=new Date(); const m=String(d.getMonth()+1).padStart(2,'0'); const day=String(d.getDate()).padStart(2,'0'); return `${d.getFullYear()}-${m}-${day}`; }
   if(btnExpQuick && expDialog){


### PR DESCRIPTION
## Summary
- replace the dashboard columns with responsive call-to-action buttons
- move each budget section into a dedicated dialog and mirror existing forms inside
- update scripts so pill summaries sync across buttons and dialogs while wiring the new modal triggers

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e04f3dcbfc83279574f750b172a3a9