### PR TITLE
Fix dialogs rendering before activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
   .progress > div{height:100%;background:linear-gradient(90deg,var(--accent),#9ce7ff);width:0%;transition:width .35s ease}
   .archiveItem{padding:12px;border:1px dashed rgba(124,155,255,.3);border-radius:12px;font-size:.82rem}
   dialog{border:1px solid color-mix(in oklch,var(--accent) 32%,transparent);background:oklch(18% 0.03 260 / .98);color:var(--surface-ink);border-radius:18px;width:min(640px,95vw);padding:0;box-shadow:0 26px 56px -30px rgba(0,0,0,.75)}
+  dialog:not([open]){display:none}
   dialog::backdrop{background:rgba(5,7,16,.7);backdrop-filter:blur(3px)}
   .dialog-head{padding:16px 18px;border-bottom:1px solid rgba(255,255,255,.08);display:flex;justify-content:space-between;align-items:center}
   .dialog-body{padding:18px;display:flex;flex-direction:column;gap:.6rem}


### PR DESCRIPTION
## Summary
- ensure dialogs stay hidden until explicitly opened by adding a CSS rule that hides non-open dialogs

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e0542e9378832791ab021414d3b22d