### PR TITLE
Fix section dialogs remaining visible after close

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,8 @@
   .dialog-body{padding:18px;display:flex;flex-direction:column;gap:.6rem}
   .dialog-actions{padding:16px 18px;border-top:1px solid rgba(255,255,255,.08);display:flex;justify-content:flex-end;gap:.6rem}
   .pill{display:inline-flex;align-items:center;gap:.5rem;padding:6px 12px;border-radius:999px;border:1px solid rgba(124,155,255,.22);font-size:.75rem;background:rgba(124,155,255,.14);color:var(--accent);font-weight:600}
-  dialog[data-section-dialog]{width:min(900px,96vw);max-height:92vh;display:flex;flex-direction:column}
+  dialog[data-section-dialog]{width:min(900px,96vw);max-height:92vh}
+  dialog[data-section-dialog][open]{display:flex;flex-direction:column}
   dialog[data-section-dialog] .dialog-body{flex:1;overflow:auto;padding:22px 24px;gap:1rem}
   .sectionDialog__summary{display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;gap:.6rem;font-size:.85rem;color:var(--muted)}
   .sectionDialog__summary .pill{margin-right:auto}


### PR DESCRIPTION
## Summary
- ensure section dialogs only apply their flex layout while the dialog is open so they disappear when closed

## Testing
- manual: open a section dialog, close it, and confirm it is hidden


------
https://chatgpt.com/codex/tasks/task_e_68e0556e45cc832798ab0448ba4ae994