### PR TITLE
Remove Kanepi control from dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,10 @@
     <span class="monthBadge" id="monthBadge" aria-live="polite">—</span>
     <button class="btn ghost icon" id="nextMonth" type="button" aria-label="Järgmine kuu">›</button>
   </div>
-  <button class="btn primary" id="expQuick" type="button">Lisa kulu</button>
+  <div class="appBar__actions">
+    <button class="btn primary" id="expQuick" type="button">Lisa kulu</button>
+    <button class="btn primary" id="adminAccessBtn" type="button">ADM</button>
+  </div>
 </header>
 
 <main class="layout">
@@ -41,11 +44,6 @@
     <button class="sectionButton" type="button" data-dialog-target="dlg-summary">
       <span class="sectionButton__label">Jooksev kokkuvõte</span>
       <span class="sectionButton__hint">Kiire ülevaade valitud kuu seisu kohta.</span>
-    </button>
-    <button class="sectionButton" type="button" data-dialog-target="dlg-zaza">
-      <span class="sectionButton__label">Kanepi tegelikkuse kontroll</span>
-      <span class="pill sectionButton__pill" data-pill="zaza">Zaza alles: —</span>
-      <span class="sectionButton__hint">Planeeri kulud ja sea vajadusel ülempiir.</span>
     </button>
     <button class="sectionButton" type="button" data-dialog-target="dlg-expenses">
       <span class="sectionButton__label">Selle kuu kulud</span>
@@ -368,6 +366,31 @@
 
 
 
+<dialog id="adminMenuDialog" aria-labelledby="adminMenuTitle">
+  <div class="dialog-head">
+    <h3 id="adminMenuTitle" style="margin:0">Administraatori menüü</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body adminMenu">
+    <section class="adminMenu__view" id="adminLockView" aria-live="polite">
+      <p class="adminMenu__hint">Kanepi tegelikkuse kontroll on ainult administraatoritele. Sisesta parool, et avada menüü.</p>
+      <label class="adminMenu__label" for="adminPasswordInput">Parool</label>
+      <input id="adminPasswordInput" type="password" autocomplete="current-password" spellcheck="false" aria-describedby="adminPasswordError">
+      <p class="err" id="adminPasswordError" hidden role="alert">Vale parool. Proovi uuesti.</p>
+      <div class="adminMenu__actions">
+        <button class="btn primary" type="button" id="adminPasswordSubmit">Ava menüü</button>
+      </div>
+    </section>
+    <section class="adminMenu__view" id="adminActionView" hidden>
+      <p class="adminMenu__hint">Vali soovitud administraatori toiming.</p>
+      <div class="adminMenu__actions">
+        <button class="btn primary adminMenu__action" type="button" data-admin-action="zaza">Kanepi tegelikkuse kontroll</button>
+      </div>
+    </section>
+  </div>
+</dialog>
+
 <script src="app.js" defer></script>
 </body>
 </html>
+

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,7 @@
   .appBar__brand{display:flex;flex-direction:column;gap:.3rem;min-width:0}
   .appBar__brand h1{font-size:1.1rem;letter-spacing:.04em}
   .appBar__meta{display:flex;flex-wrap:wrap;gap:.6rem;font-size:.78rem;color:var(--muted)}
+  .appBar__actions{display:inline-flex;align-items:center;gap:.6rem}
   .monthNav{display:inline-flex;align-items:center;gap:.4rem}
   .monthBadge{display:inline-flex;align-items:center;justify-content:center;padding:6px 14px;border-radius:999px;border:1px solid var(--accent);color:var(--accent);font-variant-numeric:tabular-nums;font-weight:600;min-width:9.5ch;text-transform:capitalize;background:rgba(101,123,255,.12)}
   .btn{border:1px solid color-mix(in oklch,var(--accent) 24%,transparent);background:linear-gradient(135deg,rgba(124,155,255,.18),rgba(124,155,255,.05));color:var(--surface-ink);padding:9px 14px;border-radius:12px;cursor:pointer;font-weight:500;font-size:.95rem;transition:transform .15s ease,box-shadow .2s ease,border-color .2s ease;background-origin:border-box;backdrop-filter:blur(4px)}
@@ -107,6 +108,12 @@
   dialog::backdrop{background:rgba(5,7,16,.7);backdrop-filter:blur(3px)}
   .dialog-head{padding:16px 18px;border-bottom:1px solid rgba(255,255,255,.08);display:flex;justify-content:space-between;align-items:center}
   .dialog-body{padding:18px;display:flex;flex-direction:column;gap:.6rem}
+  .adminMenu{gap:1rem}
+  .adminMenu__view{display:flex;flex-direction:column;gap:.75rem}
+  .adminMenu__hint{font-size:.85rem;color:var(--muted)}
+  .adminMenu__label{font-size:.82rem;color:var(--muted);font-weight:500}
+  .adminMenu__actions{display:flex;flex-wrap:wrap;gap:.6rem}
+  .adminMenu__actions .btn{flex:1;min-width:180px}
   .dialog-actions{padding:16px 18px;border-top:1px solid rgba(255,255,255,.08);display:flex;justify-content:flex-end;gap:.6rem}
   .pill{display:inline-flex;align-items:center;gap:.5rem;padding:6px 12px;border-radius:999px;border:1px solid rgba(124,155,255,.22);font-size:.75rem;background:rgba(124,155,255,.14);color:var(--accent);font-weight:600}
   dialog[data-section-dialog]{width:min(900px,96vw);max-height:92vh}
@@ -125,9 +132,10 @@
     .sectionGrid{grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1.4rem}
   }
   @media (max-width:979px){
-    header.appBar{grid-template-columns:minmax(0,1fr);grid-template-rows:auto auto auto;gap:.75rem;padding:16px 16px 14px}
+    header.appBar{grid-template-columns:minmax(0,1fr);grid-template-rows:auto auto auto auto;gap:.75rem;padding:16px 16px 14px}
     header.appBar .monthNav{order:3}
-    header.appBar .btn.primary{width:100%;order:2}
+    header.appBar .appBar__actions{order:2;display:grid;grid-template-columns:repeat(auto-fit,minmax(0,1fr));gap:.6rem}
+    header.appBar .appBar__actions .btn{width:100%}
     main.layout{grid-template-columns:1fr;padding:16px 14px 80px}
     .sectionGrid{grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1.1rem}
     .fieldRow{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- remove the Kanepi tegelikkuse kontroll button from the main section grid so it is only reachable via the admin modal

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68e05ea10aa08327bfc54d4665857bfc