### PR TITLE
Refine admin password workflow for Kanepi controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,7 +381,16 @@
         <button class="btn primary" type="button" id="adminPasswordSubmit">Ava menüü</button>
       </div>
     </section>
-    <section class="adminMenu__view" id="adminActionView" hidden>
+  </div>
+</dialog>
+
+<dialog id="adminActionsDialog" aria-labelledby="adminActionsTitle">
+  <div class="dialog-head">
+    <h3 id="adminActionsTitle" style="margin:0">Administraatori toimingud</h3>
+    <button class="btn ghost icon" type="button" data-dialog-close aria-label="Sulge">✕</button>
+  </div>
+  <div class="dialog-body adminMenu">
+    <section class="adminMenu__view" aria-live="polite">
       <p class="adminMenu__hint">Vali soovitud administraatori toiming.</p>
       <div class="adminMenu__actions">
         <button class="btn primary adminMenu__action" type="button" data-admin-action="zaza">Kanepi tegelikkuse kontroll</button>


### PR DESCRIPTION
## Summary
- move the Kanepi tegelikkuse kontroll action into a dedicated admin actions dialog shown only after authentication
- simplify the admin password dialog so it only prompts for credentials when access is locked
- update admin UI scripting to manage focus, dialog transitions, and action wiring for the Kanepi check

## Testing
- browser_container.run_playwright_script (custom Playwright flow check)


------
https://chatgpt.com/codex/tasks/task_e_68e06716044c83279f332a7efe8c49e7